### PR TITLE
Tiled levels support

### DIFF
--- a/movement/js/plugins/AltimitMovement.js
+++ b/movement/js/plugins/AltimitMovement.js
@@ -1011,13 +1011,13 @@
           if($gameMap.tiledData) {
             levels = $gameMap.getMapLevels();
           }
-          for(var levelId = 0; levelId < levels.length; levelId++) {
+          for ( var levelId = 0; levelId < levels.length; levelId++ ) {
             var level = levels[levelId];
-            var layerIds = $gameMap.getVisibleLayers(level);
+            var layerIds = $gameMap.getVisibleLayers( level );
             for( var layerIdx = 0; layerIdx < layerIds.length; layerIdx++ ) {
               var layerId = layerIds[layerIdx];
-              if($gameMap.isVisibleMesh(level, layerId)) {
-                var mesh = $gameMap.pickMesh(mapMesh, level, layerId);
+              if( $gameMap.isVisibleMesh( level, layerId ) ) {
+                var mesh = $gameMap.pickMesh( mapMesh, level, layerId );
                 var mapColliders = Collider.polygonsWithinColliderList( bboxTests[ii].x + vx, bboxTests[ii].y + vy, bboxTests[ii].aabbox, 0, 0, mesh );
                 if ( mapColliders.length > 0 ) {
                   if ( move.x !== 0 ) {
@@ -2437,13 +2437,11 @@
             return this._levels;
           }
           var levels = [];
-          for(var idx = 0; idx < Math.max(this._collisionMap.length, this._arrowCollisionMap.length); idx++) {
-            if(
-              (idx < this._collisionMap.length && this._collisionMap[idx]) ||
-              (idx < this._arrowCollisionMap.length && this._arrowCollisionMap[idx]) ||
-              (this._tileFlags && idx < this._tileFlags.length && this._tileFlags[idx])
-            ) {
-              levels.push(idx);
+          for ( var idx = 0; idx < Math.max( this._collisionMap.length, this._arrowCollisionMap.length ); idx++ ) {
+            if( ( idx < this._collisionMap.length && this._collisionMap[idx] ) ||
+              ( idx < this._arrowCollisionMap.length && this._arrowCollisionMap[idx] ) ||
+              ( this._tileFlags && idx < this._tileFlags.length && this._tileFlags[idx] ) ) {
+              levels.push( idx );
             }
           }
           this._levels = levels;
@@ -2451,32 +2449,32 @@
         }
       }
       
-      Game_Map.prototype.getVisibleLayers = function(level) {
-        if(this._visibilityLayers) {
+      Game_Map.prototype.getVisibleLayers = function( level ) {
+        if ( this._visibilityLayers ) {
           return this._visibilityLayers;
         }
         var layerIds = ['main'];
-        if(this.getPassageLayers) {
-          var layerIds2 = this.getPassageLayers(level);
-          for( var layerIdx = 0; layerIdx < layerIds2.length; layerIdx++ ) {
-            if(layerIds.indexOf(layerIds2[layerIdx]) === -1) {
-              layerIds.push(layerIds2[layerIdx]);
+        if ( this.getPassageLayers ) {
+          var layerIds2 = this.getPassageLayers( level );
+          for ( var layerIdx = 0; layerIdx < layerIds2.length; layerIdx++ ) {
+            if ( layerIds.indexOf( layerIds2[layerIdx] ) === -1 ) {
+              layerIds.push( layerIds2[layerIdx] );
             }
           }
         }
-        if(this.getIsPassableLayers) {
-          var layerIds2 = this.getIsPassableLayers(level);
-          for( var layerIdx = 0; layerIdx < layerIds2.length; layerIdx++ ) {
-            if(layerIds.indexOf(layerIds2[layerIdx]) === -1) {
-              layerIds.push(layerIds2[layerIdx]);
+        if ( this.getIsPassableLayers ) {
+          var layerIds2 = this.getIsPassableLayers( level );
+          for ( var layerIdx = 0; layerIdx < layerIds2.length; layerIdx++ ) {
+            if ( layerIds.indexOf( layerIds2[layerIdx] ) === -1 ) {
+              layerIds.push( layerIds2[layerIdx] );
             }
           }
         }
-        if(this.getTileFlagLayers) {
+        if ( this.getTileFlagLayers ) {
           var layerIds2 = this.getTileFlagLayers(level);
-          for( var layerIdx = 0; layerIdx < layerIds2.length; layerIdx++ ) {
-            if(layerIds.indexOf(layerIds2[layerIdx]) === -1) {
-              layerIds.push(layerIds2[layerIdx]);
+          for ( var layerIdx = 0; layerIdx < layerIds2.length; layerIdx++ ) {
+            if (layerIds.indexOf( layerIds2[layerIdx] ) === -1 ) {
+              layerIds.push( layerIds2[layerIdx] );
             }
           }
         }
@@ -2484,14 +2482,14 @@
           var layerLevel = 0;
           var layer = this.tiledData.layers[ii];
           if ( layer.type == "objectgroup" && layer.properties && layer.properties.collision == "mesh" ) {
-            if(layer.properties.level) {
+            if ( layer.properties.level ) {
               layerLevel = layer.properties.level;
             }
-            if( level !== layerLevel || (window.TiledManager && !TiledManager.hasHideProperties(layer)) ) {
+            if ( level !== layerLevel || ( window.TiledManager && !TiledManager.hasHideProperties( layer ) ) ) {
               continue;
             }
-            if(layerIds.indexOf(ii) === -1) {
-              layerIds.push(ii);
+            if( layerIds.indexOf(ii) === -1 ) {
+              layerIds.push( ii );
             }
           }
         }
@@ -2499,28 +2497,28 @@
         return layerIds;
       }
       
-      Game_Map.prototype.pickMesh = function(mesh, level, layerId) {
-        if($gameMap.tiledData && mesh[level]) {
+      Game_Map.prototype.pickMesh = function( mesh, level, layerId ) {
+        if ( $gameMap.tiledData && mesh[level] ) {
           mesh = mesh[level];
-          if(mesh[layerId]) {
+          if ( mesh[layerId] ) {
             mesh = mesh[layerId];
           }
         }
         return mesh;
       }
       
-      Game_Map.prototype.isVisibleMesh = function(level, layerId) {
-        return !this.tiledData || layerId === 'main' || (this.tiledData.layers[layerId] && TiledManager.checkLayerHidden(this.tiledData.layers[layerId]));
+      Game_Map.prototype.isVisibleMesh = function( level, layerId ) {
+        return !this.tiledData || layerId === 'main' || ( this.tiledData.layers[layerId] && TiledManager.checkLayerHidden( this.tiledData.layers[layerId] ) );
       }
       
-      if(!Game_Map.prototype.renderIsPassable) {
-        Game_Map.prototype.renderIsPassable = function (x, y, d) {
+      if( !Game_Map.prototype.renderIsPassable ) {
+        Game_Map.prototype.renderIsPassable = function( x, y, d ) {
           var render = 'main';
           var level = 0;
-          if(arguments.length > 2) {
+          if ( arguments.length > 2 ) {
             render = arguments[2];
           }
-          if(arguments.length > 3) {
+          if ( arguments.length > 3 ) {
             level = arguments[3];
           }
           var tempLevel = this._currentMapLevel;
@@ -2530,36 +2528,36 @@
         }
       }
       
-      if(!Game_Map.prototype.renderIsBoatPassable) {
-        Game_Map.prototype.renderIsBoatPassable = function (x, y, d) {
+      if( !Game_Map.prototype.renderIsBoatPassable ) {
+        Game_Map.prototype.renderIsBoatPassable = function( x, y, d ) {
           var render = 'main';
           var level = 0;
-          if(arguments.length > 2) {
+          if ( arguments.length > 2 ) {
             render = arguments[2];
           }
-          if(arguments.length > 3) {
+          if ( arguments.length > 3 ) {
             level = arguments[3];
           }
           var tempLevel = this._currentMapLevel;
           this._currentMapLevel = level;
-          this.isBoatPassable(x, y, d);
+          this.isBoatPassable( x, y, d );
           this._currentMapLevel = tempLevel;
         }
       }
       
-      if(!Game_Map.prototype.renderIsShipPassable) {
-        Game_Map.prototype.renderIsShipPassable = function (x, y, d) {
+      if( !Game_Map.prototype.renderIsShipPassable ) {
+        Game_Map.prototype.renderIsShipPassable = function( x, y, d ) {
           var render = 'main';
           var level = 0;
-          if(arguments.length > 2) {
+          if ( arguments.length > 2 ) {
             render = arguments[2];
           }
-          if(arguments.length > 3) {
+          if ( arguments.length > 3 ) {
             level = arguments[3];
           }
           var tempLevel = this._currentMapLevel;
           this._currentMapLevel = level;
-          this.isShipPassable(x, y, d);
+          this.isShipPassable( x, y, d );
           this._currentMapLevel = tempLevel;
         }
       }
@@ -2588,8 +2586,8 @@
       };
 
       var Game_Map_regionId = Game_Map.prototype.regionId;
-      Game_Map.prototype.regionId = function(x, y) {
-        return Game_Map_regionId.call(this, Math.floor(x), Math.floor(y));
+      Game_Map.prototype.regionId = function( x, y ) {
+        return Game_Map_regionId.call( this, Math.floor(x), Math.floor(y) );
       };
 
     } )();
@@ -2811,16 +2809,16 @@
           else if ( bboxTests[ii].type == 8 ) { offsetX -= this.width(); offsetY -= this.height(); }
 
           var levels = [0];
-          if(this.tiledData) {
+          if ( this.tiledData ) {
             levels = this.getMapLevels();
           }
-          for(var levelId = 0; levelId < levels.length; levelId++) {
+          for ( var levelId = 0; levelId < levels.length; levelId++ ) {
             var level = levels[levelId];
-            var layerIds = this.getVisibleLayers(level);
-            for( var layerIdx = 0; layerIdx < layerIds.length; layerIdx++ ) {
+            var layerIds = this.getVisibleLayers( level );
+            for ( var layerIdx = 0; layerIdx < layerIds.length; layerIdx++ ) {
               var layerId = layerIds[layerIdx];
-              if(this.isVisibleMesh(level, layerId)) {
-                var mesh = this.pickMesh(collisionMesh, level, layerId);
+              if ( this.isVisibleMesh( level, layerId ) ) {
+                var mesh = this.pickMesh( collisionMesh, level, layerId );
                 var mapColliders = Collider.polygonsWithinColliderList( bboxTests[ii].x, bboxTests[ii].y, bboxTests[ii].aabbox, 0, 0, mesh );
                 if ( mapColliders.length > 0 ) {
                   for ( var jj = 0; jj < mapColliders.length; jj++ ) {
@@ -2969,12 +2967,12 @@
         }
 
         CollisionMesh.meshInMemory.mapId = mapId;
-        CollisionMesh.meshInMemory.mesh[CollisionMesh.WALK] = CollisionMesh.makeCollisionMesh( gameMap, (gameMap.tiledData ? gameMap.renderIsPassable : gameMap.isPassable) );
+        CollisionMesh.meshInMemory.mesh[CollisionMesh.WALK] = CollisionMesh.makeCollisionMesh( gameMap, ( gameMap.tiledData ? gameMap.renderIsPassable : gameMap.isPassable ) );
         if ( !gameMap.boat().isTransparent() ) {
-          CollisionMesh.meshInMemory.mesh[CollisionMesh.BOAT] = CollisionMesh.makeCollisionMesh( gameMap, (gameMap.tiledData ? gameMap.renderIsBoatPassable : gameMap.isBoatPassable) );
+          CollisionMesh.meshInMemory.mesh[CollisionMesh.BOAT] = CollisionMesh.makeCollisionMesh( gameMap, ( gameMap.tiledData ? gameMap.renderIsBoatPassable : gameMap.isBoatPassable ) );
         }
         if ( !gameMap.ship().isTransparent() ) {
-          CollisionMesh.meshInMemory.mesh[CollisionMesh.SHIP] = CollisionMesh.makeCollisionMesh( gameMap, (gameMap.tiledData ? gameMap.renderIsShipPassable : gameMap.isShipPassable) );
+          CollisionMesh.meshInMemory.mesh[CollisionMesh.SHIP] = CollisionMesh.makeCollisionMesh( gameMap, ( gameMap.tiledData ? gameMap.renderIsShipPassable : gameMap.isShipPassable ) );
         }
         if ( !gameMap.airship().isTransparent() ) {
           CollisionMesh.meshInMemory.mesh[CollisionMesh.AIRSHIP] = CollisionMesh.makeCollisionMesh( gameMap );
@@ -3043,12 +3041,12 @@
       if ( !passFunc ) {
         passFunc = function( x, y, d ) { return true; };
       }
-      if(arguments.length < 3 && gameMap.tiledData) {
+      if ( arguments.length < 3 && gameMap.tiledData ) {
         var levels = gameMap.getMapLevels();
         var collisionMeshCollection = {};
         for( var levelIdx = 0; levelIdx < levels.length; levelIdx++) {
           var level = levels[levelIdx];
-          var layerIds = gameMap.getVisibleLayers(level);
+          var layerIds = gameMap.getVisibleLayers( level );
           var collisionMeshSubdata = {};
           
           for( var layerIdx = 0; layerIdx < layerIds.length; layerIdx++ ) {
@@ -3224,13 +3222,13 @@
         for ( var ii = 0; ii < gameMap.tiledData.layers.length; ii++ ) {
           var layerLevel = 0;
           var layer = gameMap.tiledData.layers[ii];
-          if(layer.properties && layer.properties.level) {
+          if ( layer.properties && layer.properties.level ) {
             layerLevel = layer.properties.level;
           }
-          if( level !== layerLevel ) {
+          if ( level !== layerLevel ) {
             continue;
           }
-          if(render !== 'main' && ii !== render) {
+          if ( render !== 'main' && ii !== render ) {
             continue;
           }
           for ( var yy = 0; yy < layer.height; yy++ ) {
@@ -3277,10 +3275,10 @@
           var layerLevel = 0;
           var layer = gameMap.tiledData.layers[ii];
           if ( layer.type == "objectgroup" && layer.properties && layer.properties.collision == "mesh" ) {
-            if(layer.properties.level) {
+            if ( layer.properties.level ) {
               layerLevel = layer.properties.level;
             }
-            if( level !== layerLevel ) {
+            if ( level !== layerLevel ) {
               continue;
             }
             for ( var jj = 0; jj < layer.objects.length; jj++ ) {

--- a/movement/js/plugins/AltimitMovement.js
+++ b/movement/js/plugins/AltimitMovement.js
@@ -2500,7 +2500,7 @@
       }
       
       Game_Map.prototype.pickMesh = function(mesh, level, layerId) {
-        if($gameMap.tiledData() && mesh[level]) {
+        if($gameMap.tiledData && mesh[level]) {
           mesh = mesh[level];
           if(mesh[layerId]) {
             mesh = mesh[layerId];
@@ -2510,8 +2510,60 @@
       }
       
       Game_Map.prototype.isVisibleMesh = function(level, layerId) {
-        return !this.tiledData() || layerId === 'main' || (this.tiledData.layers[layerId] && TiledManager.checkLayerHidden(this.tiledData.layers[layerId]));
+        return !this.tiledData || layerId === 'main' || (this.tiledData.layers[layerId] && TiledManager.checkLayerHidden(this.tiledData.layers[layerId]));
       }
+      
+      if(!Game_Map.prototype.renderIsPassable) {
+        Game_Map.prototype.renderIsPassable = function (x, y, d) {
+          var render = 'main';
+          var level = 0;
+          if(arguments.length > 2) {
+            render = arguments[2];
+          }
+          if(arguments.length > 3) {
+            level = arguments[3];
+          }
+          var tempLevel = this._currentMapLevel;
+          this._currentMapLevel = level;
+          this.isPassable(x, y, d);
+          this._currentMapLevel = tempLevel;
+        }
+      }
+      
+      if(!Game_Map.prototype.renderIsBoatPassable) {
+        Game_Map.prototype.renderIsBoatPassable = function (x, y, d) {
+          var render = 'main';
+          var level = 0;
+          if(arguments.length > 2) {
+            render = arguments[2];
+          }
+          if(arguments.length > 3) {
+            level = arguments[3];
+          }
+          var tempLevel = this._currentMapLevel;
+          this._currentMapLevel = level;
+          this.isBoatPassable(x, y, d);
+          this._currentMapLevel = tempLevel;
+        }
+      }
+      
+      if(!Game_Map.prototype.renderIsShipPassable) {
+        Game_Map.prototype.renderIsShipPassable = function (x, y, d) {
+          var render = 'main';
+          var level = 0;
+          if(arguments.length > 2) {
+            render = arguments[2];
+          }
+          if(arguments.length > 3) {
+            level = arguments[3];
+          }
+          var tempLevel = this._currentMapLevel;
+          this._currentMapLevel = level;
+          this.isShipPassable(x, y, d);
+          this._currentMapLevel = tempLevel;
+        }
+      }
+      /* End Tiled Additions */
 
       Game_Map.prototype.tileId = function( x, y, z ) {
         x = x | 0;
@@ -2759,7 +2811,7 @@
           else if ( bboxTests[ii].type == 8 ) { offsetX -= this.width(); offsetY -= this.height(); }
 
           var levels = [0];
-          if(this.tiledData()) {
+          if(this.tiledData) {
             levels = this.getMapLevels();
           }
           for(var levelId = 0; levelId < levels.length; levelId++) {
@@ -2917,12 +2969,12 @@
         }
 
         CollisionMesh.meshInMemory.mapId = mapId;
-        CollisionMesh.meshInMemory.mesh[CollisionMesh.WALK] = CollisionMesh.makeCollisionMesh( gameMap, gameMap.isPassable );
+        CollisionMesh.meshInMemory.mesh[CollisionMesh.WALK] = CollisionMesh.makeCollisionMesh( gameMap, (gameMap.tiledData ? gameMap.renderIsPassable : gameMap.isPassable) );
         if ( !gameMap.boat().isTransparent() ) {
-          CollisionMesh.meshInMemory.mesh[CollisionMesh.BOAT] = CollisionMesh.makeCollisionMesh( gameMap, gameMap.isBoatPassable );
+          CollisionMesh.meshInMemory.mesh[CollisionMesh.BOAT] = CollisionMesh.makeCollisionMesh( gameMap, (gameMap.tiledData ? gameMap.renderIsBoatPassable : gameMap.isBoatPassable) );
         }
         if ( !gameMap.ship().isTransparent() ) {
-          CollisionMesh.meshInMemory.mesh[CollisionMesh.SHIP] = CollisionMesh.makeCollisionMesh( gameMap, gameMap.isShipPassable );
+          CollisionMesh.meshInMemory.mesh[CollisionMesh.SHIP] = CollisionMesh.makeCollisionMesh( gameMap, (gameMap.tiledData ? gameMap.renderIsShipPassable : gameMap.isShipPassable) );
         }
         if ( !gameMap.airship().isTransparent() ) {
           CollisionMesh.meshInMemory.mesh[CollisionMesh.AIRSHIP] = CollisionMesh.makeCollisionMesh( gameMap );
@@ -2991,7 +3043,7 @@
       if ( !passFunc ) {
         passFunc = function( x, y, d ) { return true; };
       }
-      if(arguments.length < 3 && gameMap.tiledData()) {
+      if(arguments.length < 3 && gameMap.tiledData) {
         var levels = gameMap.getMapLevels();
         var collisionMeshCollection = {};
         for( var levelIdx = 0; levelIdx < levels.length; levelIdx++) {
@@ -3008,8 +3060,8 @@
         }
         return collisionMeshCollection;
       }
-      var render = false;
-      var level = false;
+      var render = 'main';
+      var level = 0;
       if ( arguments.length > 2) {
         render = arguments[2];
       }

--- a/movement/js/plugins/AltimitMovement.js
+++ b/movement/js/plugins/AltimitMovement.js
@@ -1008,7 +1008,7 @@
 
           var mapMesh = $gameMap.collisionMesh( this._collisionType );
           var levels = [0];
-          if($gameMap.isTiledMap()) {
+          if($gameMap.tiledData) {
             levels = $gameMap.getMapLevels();
           }
           for(var levelId = 0; levelId < levels.length; levelId++) {
@@ -2485,7 +2485,7 @@
       }
       
       Game_Map.prototype.pickMesh = function(mesh, level, layerId) {
-        if($gameMap.isTiledMap() && mesh[level]) {
+        if($gameMap.tiledData() && mesh[level]) {
           mesh = mesh[level];
           if(mesh[layerId]) {
             mesh = mesh[layerId];
@@ -2495,7 +2495,7 @@
       }
       
       Game_Map.prototype.isVisibleMesh = function(level, layerId) {
-        return !this.isTiledMap() || layerId === 'main' || (this.tiledData.layers[layerId] && TiledManager.checkLayerHidden(this.tiledData.layers[layerId]));
+        return !this.tiledData() || layerId === 'main' || (this.tiledData.layers[layerId] && TiledManager.checkLayerHidden(this.tiledData.layers[layerId]));
       }
 
       Game_Map.prototype.tileId = function( x, y, z ) {
@@ -2744,7 +2744,7 @@
           else if ( bboxTests[ii].type == 8 ) { offsetX -= this.width(); offsetY -= this.height(); }
 
           var levels = [0];
-          if(this.isTiledMap()) {
+          if(this.tiledData()) {
             levels = this.getMapLevels();
           }
           for(var levelId = 0; levelId < levels.length; levelId++) {
@@ -2976,7 +2976,7 @@
       if ( !passFunc ) {
         passFunc = function( x, y, d ) { return true; };
       }
-      if(arguments.length < 3 && gameMap.isTiledMap()) {
+      if(arguments.length < 3 && gameMap.tiledData()) {
         var levels = gameMap.getMapLevels();
         var collisionMeshCollection = {};
         for( var levelIdx = 0; levelIdx < levels.length; levelIdx++) {
@@ -3134,7 +3134,7 @@
       }
 
       // TileD colliders
-      if ( gameMap.tiledData && (arguments.length < 3 || (render === 'main' && level === 0)) ) {
+      if ( gameMap.tiledData ) {
         var tileWidth = gameMap.tileWidth();
         var tileHeight = gameMap.tileHeight();
         var scale = ( gameMap.isHalfTile && gameMap.isHalfTile() ) ? 2 : 1;
@@ -3155,7 +3155,17 @@
 
         // Place tile colliders
         for ( var ii = 0; ii < gameMap.tiledData.layers.length; ii++ ) {
+          var layerLevel = 0;
           var layer = gameMap.tiledData.layers[ii];
+          if(layer.properties && layer.properties.level) {
+            layerLevel = layer.properties.level;
+          }
+          if( level !== layerLevel ) {
+            continue;
+          }
+          if(render !== 'main' && ii !== render) {
+            continue;
+          }
           for ( var yy = 0; yy < layer.height; yy++ ) {
             var row = yy * layer.width;
             for ( var xx = 0; xx < layer.width; xx++ ) {
@@ -3197,8 +3207,15 @@
 
         // Find collision mesh layers
         for ( var ii = 0; ii < gameMap.tiledData.layers.length; ii++ ) {
+          var layerLevel = 0;
           var layer = gameMap.tiledData.layers[ii];
           if ( layer.type == "objectgroup" && layer.properties && layer.properties.collision == "mesh" ) {
+            if(layer.properties.level) {
+              layerLevel = layer.properties.level;
+            }
+            if( level !== layerLevel ) {
+              continue;
+            }
             for ( var jj = 0; jj < layer.objects.length; jj++ ) {
               CollisionMesh.addTileDCollisionObject( 0, 0, layer.objects[jj], scale, tileWidth, tileHeight, colliders );
             }

--- a/movement/js/plugins/AltimitMovement.js
+++ b/movement/js/plugins/AltimitMovement.js
@@ -2460,7 +2460,7 @@
           var layerIds2 = this.getPassageLayers(level);
           for( var layerIdx = 0; layerIdx < layerIds2.length; layerIdx++ ) {
             if(layerIds.indexOf(layerIds2[layerIdx]) === -1) {
-            layerIds.push(layerIds2[layerIdx]);
+              layerIds.push(layerIds2[layerIdx]);
             }
           }
         }
@@ -2468,7 +2468,7 @@
           var layerIds2 = this.getIsPassableLayers(level);
           for( var layerIdx = 0; layerIdx < layerIds2.length; layerIdx++ ) {
             if(layerIds.indexOf(layerIds2[layerIdx]) === -1) {
-            layerIds.push(layerIds2[layerIdx]);
+              layerIds.push(layerIds2[layerIdx]);
             }
           }
         }
@@ -2476,7 +2476,22 @@
           var layerIds2 = this.getTileFlagLayers(level);
           for( var layerIdx = 0; layerIdx < layerIds2.length; layerIdx++ ) {
             if(layerIds.indexOf(layerIds2[layerIdx]) === -1) {
-            layerIds.push(layerIds2[layerIdx]);
+              layerIds.push(layerIds2[layerIdx]);
+            }
+          }
+        }
+        for ( var ii = 0; ii < this.tiledData.layers.length; ii++ ) {
+          var layerLevel = 0;
+          var layer = this.tiledData.layers[ii];
+          if ( layer.type == "objectgroup" && layer.properties && layer.properties.collision == "mesh" ) {
+            if(layer.properties.level) {
+              layerLevel = layer.properties.level;
+            }
+            if( level !== layerLevel || (window.TiledManager && !TiledManager.hasHideProperties(layer)) ) {
+              continue;
+            }
+            if(layerIds.indexOf(ii) === -1) {
+              layerIds.push(ii);
             }
           }
         }


### PR DESCRIPTION
The Tiled plugin has a handy feature called levels, where you're able to switch layers to get different layers of collision. Unfortunately by default this feature does not exist in this plugin, as the entire collision mesh immediately gets rendered.

This is why I've modified the code to support multiple levels. It will now generate a new mesh for every level.

There's also an extra functionality added for a modification of Tiled which would allow people to enable and disable layers based on certain conditions. It should however be fully compatible with the current official build of Tiled.